### PR TITLE
Minor fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
-input/
-output/
+Input*/
+Output*/
 .hidden/
 __pycache__
 Scripts/Utilities/__pycache__
+venv/

--- a/Scripts/mission_infobox.py
+++ b/Scripts/mission_infobox.py
@@ -246,7 +246,7 @@ def main():
     debug_info = []
     
     try:
-        guid_lookup = guid_utils.load_guid_lookup(guid_lookup_path)
+        guid_lookup = guid_utils.create_mappings(guid_utils.load_guid_lookup(guid_lookup_path))
         debug_info.append(f"Loaded GUID lookup from: {guid_lookup_path}")
     except Exception as e:
         debug_info.append(f"Failed to load GUID lookup: {e}")

--- a/Scripts/mission_infobox.py
+++ b/Scripts/mission_infobox.py
@@ -260,7 +260,7 @@ def main():
     except Exception as e:
         debug_info.append(f"Failed to parse quests: {e}")
         write_debug_info(debug_info, debug_output_path)
-        return
+        raise
 
     try:
         formatted_quests, format_quest_debug_info = format_quest_info(quests, guid_lookup)
@@ -269,6 +269,8 @@ def main():
         debug_info.append(f"Wrote formatted quests to: {output_file_path}")
     except Exception as e:
         debug_info.append(f"Failed to format/write quests: {e}")
+        write_debug_info(debug_info, debug_output_path)
+        raise
 
     write_debug_info(debug_info, debug_output_path)
     print("Mission infoboxes have been generated and written to the output file.")

--- a/run_parser.py
+++ b/run_parser.py
@@ -48,14 +48,18 @@ def execute_script(script_path):
         with open(debug_output_path, 'a') as debug_file:
             debug_file.write(error_message)
         print(error_message)  # Print error to terminal as well
+        return False
+    return True
 
 # Change the working directory to the script's directory
 os.chdir(os.path.dirname(__file__))
 
 # Execute each script in order
 for script in scripts:
-    execute_script(script)
-    print(f"Executed {script} successfully.")
+    if execute_script(script):
+        print(f"Executed {script} successfully.")
+    else:
+        print(f"FAILED to execute {script} !  Check {debug_output_path} for details.")
 
 # Provide a link to the debug file at the end
 print(f"Debug information has been written to {debug_output_path}")

--- a/run_parser.py
+++ b/run_parser.py
@@ -1,5 +1,6 @@
 import subprocess
 import os
+import sys
 
 # List of scripts to execute (relative paths using raw strings or forward slashes)
 scripts = [
@@ -38,7 +39,7 @@ os.makedirs(os.path.dirname(debug_output_path), exist_ok=True)
 
 def execute_script(script_path):
     try:
-        result = subprocess.run(["python", script_path], check=True, capture_output=True, text=True)
+        result = subprocess.run([sys.executable, script_path], check=True, capture_output=True, text=True)
         with open(debug_output_path, 'a') as debug_file:
             debug_file.write(f"Executed {script_path} successfully.\n")
             debug_file.write(f"Output:\n{result.stdout}\n")


### PR DESCRIPTION
1.  Update `.gitignore` to ignore all `Input*` and `Output*` directories as well as a `venv` virtual environment directory
2. Fix loading of GUID mappings in `mission_infobox.py`
3. Ensure `mission_infobox.py` exceptions are propagated, so that tracebacks are reported
4. Two fixes for `run_parser.py` function `execute_script`:
    * Identify the system python interpreter rather than assuming it's just `python`
    * Make the `execute_script` function return a success value, which is then used to report to the user the success or failure of the script.